### PR TITLE
gzip.py: Explain mtime; recommend mtime = 0 to generate deterministic stream.

### DIFF
--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -160,10 +160,11 @@ class GzipFile(_compression.BaseStream):
         and 9 is slowest and produces the most compression. 0 is no compression
         at all. The default is 9.
 
-        The mtime argument is an optional numeric timestamp to be written
-        to the last modification time field in the stream when compressing.
-        If omitted or None, the current time is used.
-
+        The optional mtime argument is the timestamp requested by gzip. The time
+        is in Unix format, i.e., seconds since 00:00:00 GMT, Jan.  1, 1970.
+        If mtime is omitted or None, the current time is used. Use mtime = 0
+        to generate a compressed stream that does not depend on creation time.
+        
         """
 
         if mode and ('t' in mode or 'U' in mode):

--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -164,7 +164,7 @@ class GzipFile(_compression.BaseStream):
         is in Unix format, i.e., seconds since 00:00:00 GMT, Jan.  1, 1970.
         If mtime is omitted or None, the current time is used. Use mtime = 0
         to generate a compressed stream that does not depend on creation time.
-        
+
         """
 
         if mode and ('t' in mode or 'U' in mode):

--- a/Misc/NEWS.d/next/Documentation/2021-04-14-19-24-39.bpo-43848.gjIRIY.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-04-14-19-24-39.bpo-43848.gjIRIY.rst
@@ -1,0 +1,1 @@
+In documentation of :class:`GzipFile`, explain data type of optional constructor argument `mtime`, and recommend `mtime = 0` for generating deterministic streams.

--- a/Misc/NEWS.d/next/Documentation/2021-04-14-19-24-39.bpo-43848.gjIRIY.rst
+++ b/Misc/NEWS.d/next/Documentation/2021-04-14-19-24-39.bpo-43848.gjIRIY.rst
@@ -1,1 +1,1 @@
-In documentation of :class:`GzipFile`, explain data type of optional constructor argument `mtime`, and recommend `mtime = 0` for generating deterministic streams.
+In documentation of class `GzipFile` in module gzip, explain data type of optional constructor argument `mtime`, and recommend `mtime = 0` for generating deterministic streams.


### PR DESCRIPTION
Explain data type of optional argument mtime.

Recommend mtime = 0 for deterministic compression.

See discussion [1,2] and gzip specification [3].

[1] https://mail.python.org/archives/list/python-dev@python.org/thread/OTUGLATLYB736SAPPRWSSXWAKM5JHWZN/
[2] https://discuss.python.org/t/gzip-py-allow-deterministic-compression-without-time-stamp/8221
[3] https://www.ietf.org/rfc/rfc1952.txt